### PR TITLE
CSS Cleanup + Auto Dark Mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto
+
+*.css text diff=css
+*.htm text diff=html
+*.html text diff=html
+*.py text diff=python
+*.scss text diff=css
+*.markdown text diff=markdown
+*.md text diff=markdown
+
+*.gif binary
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.pdf binary
+*.png binary
+*.svg text
+*.webp binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 *.htm text diff=html
 *.html text diff=html
 *.py text diff=python
-*.scss text diff=css
 *.markdown text diff=markdown
 *.md text diff=markdown
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 .*.swp
-
 */*
 index.html
-
 !text/*
 !img/*
 !js/*
-
-

--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,14 @@
 # thank u for working on our web sight
 
+## How to develop locally
+
+1. Be sure you have soupault and python installed
+2. Either run `bash ./watch.sh` or manually invoke soupault and `python -m http.server --directory .`
+3. ???
+
 ## How to write pages
 
-Make a new file called `blah.html` in the `text` dir. The result will be that this appears at https://altrac.works/blah/
+Make a new file called `blah.html` in the `text` dir. The result will be that this appears at `https://altrac.works/blah/`
 
 Remember, the `/call/` url is special and currently is not in this repo.
 
@@ -14,4 +20,3 @@ Remember, the `/call/` url is special and currently is not in this repo.
     - This step will not really update the site contents but it *could* result in changes, for instance, if the css has changed, `git pull` will apply that change immediately.
 4. `~/bin/soupault`
     - This final step actually generates the site.
-

--- a/altrac.css
+++ b/altrac.css
@@ -1,41 +1,161 @@
 * {
-    --white: #ffffff;
-    --trans-blue: #64C9F9;
-    --trans-pink: #F0A5B7;
-    --grAAAAAAy: #AAAAAA;
-
-    font-family: 'Cantarell', sans-serif;
-    color: #000000;
+	--black: #242424;
+	--lightgray: #d3d3d3;
+	--gray: #aaaaaa;
+	--trans-blue: #64c9f9;
+	--trans-pink: #f0a5b7;
+	--trans-pink-contrast: #ffb5c7;
+	--white: #ffffff;
 }
 
-html, body {
-    margin: 0;
-    padding: 0;
-
-    font-size: 110%;
-    line-height: 1.6;
+html {
+	/* Improve consistency of default fonts in browsers, respect system defaults */
+	font-family: "Cantarell", system-ui, "Segoe UI", Roboto, Helvetica, Arial,
+		sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+	font-size: 1.2rem;
+	line-height: 1.6;
+	tab-size: 4;
+	-webkit-text-size-adjust: 100%;
 }
 
 body {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
+	color: black;
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	min-height: 100vh;
 }
 
 header {
-    background-color: var(--trans-pink);
-    padding: 0.5em 1em;
-    
-    display: grid;
-    grid-template-columns: 140px auto;
-    align-items: center;
+	align-items: center;
+	display: inline-flex;
+	background-color: var(--trans-pink);
+	padding: 1rem;
 }
+
 header img {
-    width: 140px;
-    padding-right: 1em;
+	width: 7.5rem;
 }
-header h1 {
-    font-size: 200%;
+
+main {
+	display: flex;
+	flex: 1;
+	flex-direction: row;
+	padding: 1rem;
+}
+
+main div {
+	flex: 1;
+}
+
+/* a little counterintuitive but remember nav is right above footer (20240209) */
+nav {
+	background-color: var(--lightgray);
+	padding: 0.5rem 1rem;
+}
+
+nav :not(:last-child):after {
+	content: " • ";
+	margin-left: 0.375rem;
+	display: inline-block;
+}
+
+footer {
+	background-color: var(--gray);
+	padding: 0.5rem 1rem;
+}
+
+a {
+	color: black;
+}
+
+a:hover,
+.link-btn:hover {
+	cursor: pointer;
+	opacity: 85%;
+}
+
+button.link-btn {
+	border: 0;
+	margin-left: 0;
+}
+
+input {
+	font-size: 2rem;
+}
+
+.link-btn {
+	background-color: var(--trans-blue);
+	border-radius: 1.25rem;
+	display: block;
+	font-size: 1.3rem;
+	margin: 1.125rem;
+	padding: 1.125rem;
+	text-align: center;
+	text-decoration: none;
+}
+
+.button-row {
+	display: flex;
+}
+
+.button-row * {
+	flex: 1;
+}
+
+.button-row .link-btn {
+	font-size: min(1.2rem, 6vw);
+	margin: 0.25rem;
+	padding: 0.75rem;
+}
+
+ol.list-with-links {
+	list-style-type: none;
+	padding: 0;
+}
+
+ol.list-with-links li {
+	display: flex;
+	border-top: 1px solid var(--lightgray);
+}
+
+ol.list-with-links li * {
+	flex: 1;
+}
+
+.socials {
+	text-align: center;
+	border: 2px dashed var(--trans-blue);
+	padding: 0.3em 0;
+}
+
+.mobile-only {
+	display: none;
+}
+
+.nobreak {
+	white-space: nowrap;
+}
+
+aside.promotion {
+	background-color: var(--trans-blue);
+	font-size: 1rem;
+	font-weight: bold;
+	padding: 16px;
+	text-align: center;
+}
+
+aside.promotion a {
+	text-decoration: none;
+}
+
+aside.promotion a .fake-link {
+	text-decoration: underline;
+}
+
+aside.promotion a em {
+	display: block;
+	font-size: 1.15rem;
 }
 
 /*The weirdness is if we have 2 of these,
@@ -51,136 +171,77 @@ header h1 {
  * will be #FFB5C7. But god help us if we ever
  * have more than 2 banners. */
 aside.promotion:last-of-type {
-    background-color:#FFB5C7;
-}
-aside.promotion {
-    background-color:var(--trans-blue);
-    padding:16px;
-    font-weight:bold;
-    font-size:1.05em;
-    /*ok ally*/
-    text-align:center;
-}
-aside.promotion a {
-    text-decoration:none;
-}
-aside.promotion a .fake-link {
-    text-decoration:underline;
-}
-aside.promotion a em {
-    display:block; /*ok ally*/
-    font-size:1.15em;
+	background-color: var(--trans-pink-contrast);
 }
 
-/* a little counterintuitive but remember nav is right above footer (20240209) */
-nav {
-    background-color:lightgray;
-    padding: 0.5em 1em;
-}
-nav :not(:last-child):after {
-    content:" • ";
-    text-decoration:none;
-    display:inline-block;
-    margin-left:5px; /* ??? caused by inline-block, why is it uneven tho */
-}
-footer {
-    background-color: var(--grAAAAAAy);
-    padding: 0.5em 1em;
+/* Dark theme */
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: var(--black);
+		color: var(--white);
+	}
+
+	a {
+		color: var(--white);
+	}
+
+	/* nasty reset, ugh i wish we had nesting :/ */
+	/* this is totally gonna break one day */
+	header,
+	nav,
+	footer,
+	header > h1 > a,
+	nav > a,
+	footer > a,
+	.link-btn {
+		color: initial;
+	}
 }
 
-main {
-    padding: 1em;
-    display: flex;
-    flex-direction: row;
-    flex: 1;
+@media (min-width: 600px) {
+	/* lol */
+	.absurdnobreakhackforheader {
+		white-space: nowrap;
+	}
 }
 
-main div {
-    flex: 1;
+/* Small breakpoints */
+@media (max-width: 900px) {
+	header h1 {
+		font-size: 1.5rem;
+	}
+
+	main {
+		flex-direction: column;
+	}
+
+	.link-btn {
+		margin: 1rem 0;
+	}
+
+	.not-mobile {
+		display: none;
+	}
+
+	.mobile-only {
+		display: block;
+	}
+
+	ol.list-with-links li {
+		flex-direction: column;
+	}
 }
 
-.link-btn {
-    display: block;
-    font-size: 1.3em;
-    margin: 1em;
-    padding: 1em;
-    text-align: center;
-    background-color: var(--trans-blue);
-    text-decoration: none;
-    border-radius: 20px;
-}
-button.link-btn {
-    /* lol */
-    margin-left: 0;
-    border: 0;
-}
-input {
-    font-size: 2em;
-}
+/* Medium breakpoints */
+@media (min-width: 900px) {
+	main img {
+		height: min-content;
+		width: min-content;
+		max-width: 40%;
+		margin: 1.5rem;
+	}
 
-/*Support page shenanigans*/
-ol.list-with-links {
-    list-style-type:none;
-    padding:0;
-}
-ol.list-with-links li {
-    display:flex;
-    border-top:1px solid lightgray;
-}
-ol.list-with-links li * {
-    flex:1;
-}
-
-/*social media share buttons*/
-.socials {
-    text-align:center;
-    border: 2px dashed var(--trans-blue);
-    padding: 0.3em 0;
-}
-.button-row {
-    display:flex;
-}
-.button-row * {
-    flex:1;
-}
-.button-row .link-btn {
-    margin:.25em;
-    padding:.75em;
-    font-size:min(1.1em, 6vw);
-}
-
-.mobile-only { display: none; }
-/*.not-mobile { display: block; }*/
-
-.nobreak { white-space: nowrap; }
-
-@media(min-width: 600px) {
-    .absurdnobreakhackforheader { white-space: nowrap; }
-}
-/*pride in the park*/
-@media(min-width: 900px) {
-    main img {
-        max-width:40%;
-        margin:24px;
-        height:min-content; /*otherwise it freaking grows to the height of the other flex thing*/
-    }
-    .button-row {
-        padding:0 1em;
-    }
-}
-@media(max-width: 900px) {
-    main {
-        flex-direction: column;
-    }
-    .link-btn {
-        margin: 1em 0;
-    }
-    .not-mobile { display: none; }
-    .mobile-only { display: block; }
-
-    header h1 { font-size: 1.3em; }
-
-    ol.list-with-links li {
-        flex-direction:column;
-    }
+	.button-row {
+		padding: 0 1rem;
+	}
 }

--- a/template.j2
+++ b/template.j2
@@ -8,14 +8,14 @@
 
         <meta name="title" content="Alabama Transgender Rights Action Coalition">
         <meta name="description" content="ALTRAC provides the information you need to help protect the rights of transgender Alabamians. Learn how to contact your state representatives, and find out about local rallies where you can make your voice heard.">
-        
+
         <!-- Open Graph / Facebook -->
         <meta property="og:type" content="website">
         <!-- <meta property="og:url" content="https://altrac.works/"> -->
         <meta property="og:title" content="Alabama Transgender Rights Action Coalition">
         <meta property="og:description" content="ALTRAC provides the information you need to help protect the rights of transgender Alabamians. Learn how to contact your state representatives, and find out about local rallies where you can make your voice heard.">
         <!-- <meta property="og:image" content="logo.png"> -->
-        
+
         <!-- Twitter -->
         <meta property="twitter:card" content="summary">
         <!-- <meta property="twitter:url" content="https://altrac.works/"> -->
@@ -28,7 +28,7 @@
     </head>
     <body>
         <header>
-            <img src="/img/logoCv2.svg">
+            <img src="/img/logoCv2.svg" alt="The Alabama Transgender Rights Action Coalition logo, Alabama state borders with a transgender flag overlayed on top of of the state flag crimson cross.">
             <h1>Alabama Transgender Rights <span class="absurdnobreakhackforheader">Action Coalition</span></h1>
         </header>
 

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# who needs an actual dev script lmao
+# no warranty is provided
+
+while sleep 5; do
+  soupault
+done &
+python -m http.server --directory .


### PR DESCRIPTION
# CSS Cleanup + Dark Mode Support

This implements an automatic dark theme for the website dependent on the user's system theme settings (the default is still light mode, however). This also cleans up and restructures the main stylesheet, as well as some other small improvements.

Please god review my changes locally because I'm sure some weird edge case that I somehow missed exploded.

![image](https://github.com/user-attachments/assets/8adc2457-f556-441f-a0f2-f3142f1aef3a)

## Features

- Added an automatic dark theme that kicks in if the user has their browser/system to dark mode

## Accessibility improvements

- Append alt text to current images
- Use rem when possible instead of em/px
- Added a slight hover opacity change on buttons/links with hidden text-decoration
- Slightly more consistent nav link spacing instead of forcing a specific amount of px
- Improved consistency of system font fallbacks for users that force their own browser font

## Chores

- Fixed a few little jank CSS things here and there
- Massively restructured/cleaned up the CSS stylesheet and attributes
- Added an inline development server bash script because I'm forgetful
- Updated gitattributes to properly store binary files as binary in case of jank
- Formatted everything consistently (if you want spaces, edit `.editorconfig` and re-format
